### PR TITLE
feat: implemented unary not + unit tests

### DIFF
--- a/query.pest
+++ b/query.pest
@@ -4,8 +4,10 @@ operation = _{and | or}
   and = {"&"}
   or = {"|"}
 
+unary_not = {"!"}
+
 expr = {term ~ (operation ~ term)*}
-  term = _{tag | "(" ~ expr ~ ")"}
+  term = _{unary_not* ~ tag | "(" ~ expr ~ ")"}
 
 tagsearch = _{SOI ~ expr ~ EOI}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,12 +12,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let ast = construct_query_ast(
-        QueryParser::parse(Rule::tagsearch, "(#a & #b | (#c & #d)) & #e")
+        QueryParser::parse(Rule::tagsearch, "!#e")
             .unwrap()
             .next()
             .unwrap()
             .into_inner(),
-        vec!["#a", "#c", "#d", "#e"],
+        vec!["#a", "#c", "#d"],
     );
 
     println!("{:#?}", ast);


### PR DESCRIPTION
Implement a unary not operator (`!`) in tag search queries.